### PR TITLE
Enable syntax highlighting for AdBlock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+[attr]adb linguist-language=AdBlock linguist-detectable
+
+*.txt adb
+/script/**/*.txt -adb
+/rules/fasthosts.txt -adb


### PR DESCRIPTION
Support for AdBlock filter lists was [recently added](https://github.com/github/linguist/pull/5968) to GitHub Linguist. However, only `.txt` files beginning with an obvious-looking header are classified as filter-lists, which rules out most/all of the filter-lists in this repository.

This PR [adds an override](https://github.com/github/linguist/blob/master/docs/overrides.md) to declare the language of this project's `.txt` files explicitly.

(Note that adding/updating a `.gitattributes` file won't affect a project's language classification until another commit is pushed, which forces GitHub to recalculate the repo's language stats)