### PR TITLE
Update dns.txt

### DIFF
--- a/dns.txt
+++ b/dns.txt
@@ -6533,9 +6533,6 @@
 ||adserversolutions.com^
 ||adservi.com^
 ||adservice.google.*^
-||adservice.google.be^
-||adservice.google.co.za^
-||adservice.google.cz^
 ||adservice.sigmob.cn^
 ||adservicemedia.dk^
 ||adserviceretry.kugou.com^


### PR DESCRIPTION
||adservice.google.*^ will block any domain beyond "google." No need for the following:
adservice.google.be
adservice.google.co.za
adservice.google.cz