### PR TITLE
fix: add vaserviece.10jqka.com.cn to DNS allowlist for 同花顺 alarm

### DIFF
--- a/mod/rules/dns-allowlist.txt
+++ b/mod/rules/dns-allowlist.txt
@@ -256,6 +256,8 @@ tdid.m.qq.com
 #! 乱七八糟的域名 白名单 Start !#
 #同花顺预测
 adm.10jqka.com.cn
+#同花顺预警（增值服务API网关）
+vaserviece.10jqka.com.cn
 
 #Volkswagen #246
 d2cmedia.ca


### PR DESCRIPTION
问题
同花顺（10jqka）智能预警功能不可用，打开后页面空白。

原因
预警全部 API 接口均部署在 vaserviece.10jqka.com.cn：
/iwcalarm/nlp/v1/check_user_used
/iwcalarm/nlp/v1/query_warn_cond
/iwcalarm/nlp/v1/get_push_frequency
/iwcalarm/nlp/v1/get_warn_limit
/iwcalarm/nlp/v1/get_push_info
/alarm_v2/open/api/mobile/v2/page_query_warn_info
/alarm/index.php

qx.conf 第 161522 行将其作为 vas* 广告域名批量误拦。

修复
在 dns-allowlist.txt 中新增 vaserviece.10jqka.com.cn。

背景
此前 #252 已有人反馈同花顺预警被拦，但当时只加了 adm.10jqka.com.cn（广告推荐接口），
并未覆盖实际的预警 API 域名，问题从 4 月遗留至今。本次为补充修复。

结论
已经测试完毕，预警功能恢复使用。